### PR TITLE
Update README.md - File Versioning through CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Based on the idea of [digitalvillainy's loremFill](https://github.com/digitalvil
 
 CDN: Place the following script tag into your project 
 
-`<script src="https://cdn.jsdelivr.net/gh/sroehrl/fillr/fillr.min.js" defer></script>`
+`<script src="https://cdn.jsdelivr.net/gh/sroehrl/fillr@v0.2.0/fillr.min.js" defer></script>`
+
+Replace @vX.X.X with desired version found from: [Available versions of Fillr](https://github.com/sroehrl/fillr/tags)
 
 Just fill in {{lorem}} wherever you please. You can utilize basic functions:
 


### PR DESCRIPTION
Currently the script is distributed through jsDelivr - using the URL `https://cdn.jsdelivr.net/gh/sroehrl/fillr/fillr.min.js` 

The CDN and user's browser can aggressively cache files. Once `fillr.min.js` is cached either on user browser or the CDN, it can be stored for a long period of time before being updated to the latest version of the file. This poses an issue, because if any static files are updated in the repo, it will be some time before the end-user can use the updated version.

To solve such aggressive caching, cache busting must be utilized.  Common methods of cache busting include **file name versioning**  - `foo.v2.js`, **file path versioning** - `/v2/foo.js`,  **query strings** - `foo.js?version=2`.  

Fillr uses jsDelivr. JsDevlier uses this URL format for Github repo's `https://cdn.jsdelivr.net/gh/user/repo@version/file`

The current url does not take advantage of the `@version` parameter.

**TL;DR**
This pull-request updates README.md to include the `@version` parameter in script reference example, to circumvent the aggressive caching behavior of static files on the jsDelivr CDN and user's browser.  

**Addresses Issue:**
#2   